### PR TITLE
typo

### DIFF
--- a/python/prebound-methods/index.rst
+++ b/python/prebound-methods/index.rst
@@ -98,7 +98,7 @@ and correctly reset its state before the next test runs.
 
 Third, this approach abandons encapsulation.
 This will sound like a fuzzier complaint
-then the previous two,
+than the previous two,
 but it can detract from readability
 (“readability counts”)
 for a small tight system of two functions and a ``seed``


### PR DESCRIPTION
One small typo corrected.

Note:  
The `up` in `...available **up** at a module’s global level.` seemed a bit strange, but I am not a native English speaker, so maybe it is not - I left it unchanged:

> But for lightweight objects that can be instantiated without substantial delay or complication, the Prebound Methods pattern is an elegant way to make the stateful behavior of a class instance available up at a module’s global level.

(paragraph towards the end)