### PR TITLE
Add missing `self` param to gang-of-four/builder/index.rst

### DIFF
--- a/gang-of-four/builder/index.rst
+++ b/gang-of-four/builder/index.rst
@@ -242,7 +242,7 @@ as it responds to calls describing the creation of a maze
 
     class StandardMazeBuilder(object):
         # ...
-        def build_door(n1, n2):
+        def build_door(self, n1, n2):
             room1 = self._current_maze.get_room(n1)
             room2 = self._current_maze.get_room(n2)
             door = Door(r1, r2)


### PR DESCRIPTION
A tiny change to add the `self` parameter to this instance method.